### PR TITLE
Add component finder

### DIFF
--- a/ddl/__init__.py
+++ b/ddl/__init__.py
@@ -11,6 +11,7 @@ import math
 from ddl.renderer import Renderer
 from ddl.projection import IsometricProjection, TopDownProjection
 from ddl.asset import ComponentAsset, ImageAsset
+from ddl.taglist import TagList
 
 
 class ProjectionTypeException(Exception):
@@ -49,6 +50,7 @@ class Assetpack:
         self.images = {}
         self.name = name
         self.grid = components_and_grid['grid']
+        self.taglist = TagList()
         if self.grid['type'] == 'isometric':
             self.projection = IsometricProjection(self.grid['width'],
                                                   self.grid['height'])
@@ -62,6 +64,7 @@ class Assetpack:
 
         for component in components_and_grid['components']:
             new_component = ComponentAsset(component, assetpack_name=name)
+            self.taglist.add_component(new_component)
             self.add_component(new_component)
 
     def add_component(self, new_asset):
@@ -94,6 +97,8 @@ class Assetpack:
             self.add_image(image)
         for component in assetpack.components.values():
             self.add_component(component)
+
+        self.taglist.append(assetpack.taglist)
 
     def change_assetpack_name(self, new_name):
         """

--- a/ddl/asset.py
+++ b/ddl/asset.py
@@ -52,29 +52,20 @@ class ComponentAsset(Asset):
         for sub_part in self.parts:
             sub_part["asset_id"] = self.get_part_full_id(sub_part)
 
-    def get_image_location_list(self, offset_x, offset_y, assetpack):
-        """Recursively moves down a component, finally returning a list of
-         images and their offsets, given some already known pixel offset
-         values."""
-        image_location_list = []
-        for sub_asset in self.parts:
-            if sub_asset["type"] == "image":
-                sub_component = assetpack.images[sub_asset["asset_id"]]
-                sub_offset_x = sub_asset["x"]+offset_x
-                sub_offset_y = sub_asset["y"]+offset_y
-                image_location_list = image_location_list+[(
-                    sub_component, sub_offset_x, sub_offset_y
-                )]
-            else:
-                sub_component = assetpack.components[sub_asset["asset_id"]]
-                sub_offset_x = sub_asset["x"]+offset_x
-                sub_offset_y = sub_asset["y"]+offset_y
-                new_ill = sub_component.get_image_location_list(
-                                                          sub_offset_x,
-                                                          sub_offset_y,
-                                                          assetpack)
-                image_location_list = image_location_list+new_ill
-        return image_location_list
+    def get_part_list(self, offset_x, offset_y):
+        """Moves down a component and returns its list of parts
+        given some coordinate grid offset."""
+        part_list = []
+        for part in self.parts:
+            part_offset_x = part["x"]+offset_x
+            part_offset_y = part["y"]+offset_y
+            part_list = part_list+[(
+                part["type"],
+                part["asset_id"],
+                part_offset_x,
+                part_offset_y
+            )]
+        return part_list
 
     def get_part_full_id(self, sub_part):
         """Gives the correct part id, given the assetpack."""

--- a/ddl/taglist.py
+++ b/ddl/taglist.py
@@ -9,16 +9,38 @@ class TagList:
     def __init__(self):
         self.tag_components = {}
 
-    def add_component_to_tag(self, tag, component_name):
-        self.tag_components.setdefault(tag, set()).add(component_name)
+    def add_component_to_tag(self, tag, component_id):
+        """Adds a component ID to the list of components matching a tag"""
+        self.tag_components.setdefault(tag, set()).add(component_id)
 
     def add_component(self, component):
+        """
+        Adds a component's ID to the tag_component list for all the
+        component's tags.
+        """
         component_id = component.get_full_id()
         for tag in component.tags:
             self.add_component_to_tag(tag, component_id)
 
     def append(self, taglist):
+        """Sticks two taglists together"""
         tag_components = taglist.tag_components
         for tag, components in tag_components.items():
             self.tag_components.setdefault(tag,
                                            set()).update(components)
+
+    def get_components_that_match_tags(self, tags):
+        """
+        For an array of tags, goes through and finds the ID of all components
+        that match all tags. Returns an empty set if one of the tags is missing
+        or if no component matches all tags.
+        """
+        for tag in tags:
+            if tag not in self.tag_components.keys():
+                return(set())
+
+        good_components = self.tag_components[tags.pop(0)]
+        for tag in tags:
+            components = self.tag_components[tag]
+            good_components = good_components.intersection(components)
+        return(good_components)

--- a/ddl/taglist.py
+++ b/ddl/taglist.py
@@ -1,0 +1,24 @@
+"""Adds a class to store and retrieve names of components, given their tags"""
+
+
+class TagList:
+    """
+    A class that stores and retrieves names of components given their
+    tag lists. Basically a fancy lookup class for faster/easier tag handling.
+    """
+    def __init__(self):
+        self.tag_components = {}
+
+    def add_component_to_tag(self, tag, component_name):
+        self.tag_components.setdefault(tag, set()).add(component_name)
+
+    def add_component(self, component):
+        component_id = component.get_full_id()
+        for tag in component.tags:
+            self.add_component_to_tag(tag, component_id)
+
+    def append(self, taglist):
+        tag_components = taglist.tag_components
+        for tag, components in tag_components.items():
+            self.tag_components.setdefault(tag,
+                                           set()).update(components)

--- a/tests/test_taglist.py
+++ b/tests/test_taglist.py
@@ -29,15 +29,43 @@ def test_add_component_to_tag():
         raise AssertionError()
 
 
-def combined_component_check(tag_components):
+def make_add_taglist():
     """
-    Runs checks on component lists that are meant to include combinations of
-    component and tag. This is a measure to have tidy code.
+    Makes a taglist and adds some components to it.
+    Really overloading the tests here, but hey.
     """
+    component1 = FakeComponent("component1", ['tag1', 'tag2'])
+    component2 = FakeComponent("component2", ['tag2', 'tag3'])
+    taglist = TagList()
+    taglist.add_component(component1)
+    taglist.add_component(component2)
+    return (taglist)
+
+
+def test_add_component_right_tags():
+    """
+    Checks that adding components modifies the tag_component tags correctly.
+    """
+    tag_components = make_add_taglist().tag_components
     if "tag1" and "tag2" and "tag3" not in tag_components.keys():
         raise AssertionError(tag_components.keys())
+
+
+def test_add_component_right_components():
+    """
+    Checks that adding components modifies the tag_component components
+    correctly.
+    """
+    tag_components = make_add_taglist().tag_components
     if "component1" and "component2" not in tag_components["tag2"]:
         raise AssertionError()
+
+
+def test_add_component_right_sizes():
+    """
+    Checks that adding components gives the right size sets back afterwards.
+    """
+    tag_components = make_add_taglist().tag_components
     if not len(tag_components["tag1"]) == 1:
         raise AssertionError()
     if not len(tag_components["tag2"]) == 2:
@@ -46,21 +74,10 @@ def combined_component_check(tag_components):
         raise AssertionError()
 
 
-def test_add_component():
+def make_append_taglist():
     """
-    Checks that adding components modifies the tag_component list correctly.
-    """
-    component1 = FakeComponent("component1", ['tag1', 'tag2'])
-    component2 = FakeComponent("component2", ['tag2', 'tag3'])
-    taglist = TagList()
-    taglist.add_component(component1)
-    taglist.add_component(component2)
-    combined_component_check(taglist.tag_components)
-
-
-def test_append_taglist():
-    """
-    Checks that appending taglists works correctly and is commutative.
+    Makes tow taglists and sticks them together.
+    Really overloading the tests here, but hey.
     """
     component1 = FakeComponent("component1", ['tag1', 'tag2'])
     component2 = FakeComponent("component2", ['tag2', 'tag3'])
@@ -69,35 +86,99 @@ def test_append_taglist():
     taglist2 = TagList()
     taglist2.add_component(component2)
     taglist1.append(taglist2)
-    taglist2.append(taglist1)
-    combined_component_check(taglist1.tag_components)
-    combined_component_check(taglist2.tag_components)
+    return(taglist1)
 
 
-def test_get_component_list():
+def test_append_component_right_tags():
+    """
+    Checks that appending taglists modifies the tag_component tags correctly.
+    """
+    tag_components = make_append_taglist().tag_components
+    if "tag1" and "tag2" and "tag3" not in tag_components.keys():
+        raise AssertionError(tag_components.keys())
+
+
+def test_append_component_right_components():
+    """
+    Checks that appending taglists modifies the tag_component components
+    correctly.
+    """
+    tag_components = make_append_taglist().tag_components
+    if "component1" and "component2" not in tag_components["tag2"]:
+        raise AssertionError()
+
+
+def test_append_component_right_sizes():
+    """
+    Checks that appending components gives the right size sets back afterwards.
+    """
+    tag_components = make_append_taglist().tag_components
+    if not len(tag_components["tag1"]) == 1:
+        raise AssertionError()
+    if not len(tag_components["tag2"]) == 2:
+        raise AssertionError()
+    if not len(tag_components["tag3"]) == 1:
+        raise AssertionError()
+
+
+def test_get_list_single_tags_1():
     """
     Checks that getting component lists given a set of tags works correctly.
+    This only checks a single tag at a time.
     """
-    component1 = FakeComponent("component1", ['tag1', 'tag2'])
-    component2 = FakeComponent("component2", ['tag2', 'tag3'])
-    taglist = TagList()
-    taglist.add_component(component1)
-    taglist.add_component(component2)
+    taglist = make_add_taglist()
+    tag2_components = taglist.get_components_that_match_tags(["tag2"])
     if not len(taglist.get_components_that_match_tags(["tag1"])) == 1:
         raise AssertionError()
     if "component1" not in taglist.get_components_that_match_tags(["tag1"]):
         raise AssertionError()
-    if not len(taglist.get_components_that_match_tags(["tag2"])) == 2:
+
+
+def test_get_list_single_tags_1():
+    """
+    Checks that getting component lists given a set of tags works correctly.
+    This only checks a single tag at a time.
+    """
+    taglist = make_add_taglist()
+    tag2_components = taglist.get_components_that_match_tags(["tag2"])
+    if not len(tag2_components) == 2:
+        raise AssertionError()
+    if "component1" not in tag2_components:
+        raise AssertionError()
+    if "component2" not in tag2_components:
         raise AssertionError()
 
+
+def test_get_list_double_tags():
+    """
+    Checks that getting component lists given a set of tags works correctly.
+    This test checks multiple tags return just the one component.
+    """
+    taglist = make_add_taglist()
     double_tag_list = taglist.get_components_that_match_tags(["tag2", "tag3"])
     if not len(double_tag_list) == 1:
         raise AssertionError()
     if "component2" not in double_tag_list:
         raise AssertionError()
 
+
+def test_get_list_missing_tag():
+    """
+    Checks that getting component lists given a set of tags works correctly.
+    This checks that a tag that isn't in the artpack returns an empty list.
+    """
+    taglist = make_add_taglist()
     if not len(taglist.get_components_that_match_tags(["tag_umpt"])) == 0:
         raise AssertionError()
+
+
+def test_get_list_single_tags():
+    """
+    Checks that getting component lists given a set of tags works correctly.
+    This tests that asking for a combination of tags that doesnt exist
+    returns an empty list.
+    """
+    taglist = make_add_taglist()
     if not len(taglist.get_components_that_match_tags(["tag1",
                                                        "tag2",
                                                        "tag3"])) == 0:

--- a/tests/test_taglist.py
+++ b/tests/test_taglist.py
@@ -42,7 +42,7 @@ def make_add_taglist():
     return (taglist)
 
 
-def test_add_component_right_tags():
+def test_add_right_tags():
     """
     Checks that adding components modifies the tag_component tags correctly.
     """
@@ -51,7 +51,7 @@ def test_add_component_right_tags():
         raise AssertionError(tag_components.keys())
 
 
-def test_add_component_right_components():
+def test_add_right_components():
     """
     Checks that adding components modifies the tag_component components
     correctly.
@@ -61,7 +61,7 @@ def test_add_component_right_components():
         raise AssertionError()
 
 
-def test_add_component_right_sizes():
+def test_add_right_sizes():
     """
     Checks that adding components gives the right size sets back afterwards.
     """
@@ -89,7 +89,7 @@ def make_append_taglist():
     return(taglist1)
 
 
-def test_append_component_right_tags():
+def test_append_right_tags():
     """
     Checks that appending taglists modifies the tag_component tags correctly.
     """
@@ -98,7 +98,7 @@ def test_append_component_right_tags():
         raise AssertionError(tag_components.keys())
 
 
-def test_append_component_right_components():
+def test_append_right_components():
     """
     Checks that appending taglists modifies the tag_component components
     correctly.
@@ -108,7 +108,7 @@ def test_append_component_right_components():
         raise AssertionError()
 
 
-def test_append_component_right_sizes():
+def test_append_right_sizes():
     """
     Checks that appending components gives the right size sets back afterwards.
     """
@@ -127,14 +127,14 @@ def test_get_list_single_tags_1():
     This only checks a single tag at a time.
     """
     taglist = make_add_taglist()
-    tag2_components = taglist.get_components_that_match_tags(["tag2"])
-    if not len(taglist.get_components_that_match_tags(["tag1"])) == 1:
+    tag1_components = taglist.get_components_that_match_tags(["tag1"])
+    if not len(tag1_components) == 1:
         raise AssertionError()
-    if "component1" not in taglist.get_components_that_match_tags(["tag1"]):
+    if "component1" not in tag1_components:
         raise AssertionError()
 
 
-def test_get_list_single_tags_1():
+def test_get_list_single_tags_2():
     """
     Checks that getting component lists given a set of tags works correctly.
     This only checks a single tag at a time.
@@ -172,7 +172,7 @@ def test_get_list_missing_tag():
         raise AssertionError()
 
 
-def test_get_list_single_tags():
+def test_get_list_fail_combo():
     """
     Checks that getting component lists given a set of tags works correctly.
     This tests that asking for a combination of tags that doesnt exist

--- a/tests/test_taglist.py
+++ b/tests/test_taglist.py
@@ -1,0 +1,73 @@
+"""Tests TagList"""
+
+from ddl.taglist import TagList
+
+
+class FakeComponent:
+    """A fake component"""
+    def __init__(self, name, tags):
+        self.name = name
+        self.tags = tags
+
+    def get_full_id(self):
+        return (self.name)
+
+
+def test_add_component_to_tag():
+    """Checks adding a component name to a tag functions as expected"""
+    taglist = TagList()
+    taglist.add_component_to_tag("test", "component1")
+    taglist.add_component_to_tag("test", "component2")
+    taglist.add_component_to_tag("test2", "component3")
+    if not len(taglist.tag_components["test"]) == 2:
+        raise AssertionError()
+    if not len(taglist.tag_components["test2"]) == 1:
+        raise AssertionError()
+    # The hell is this syntax?
+    if "component1" and "component2" not in taglist.tag_components["test"]:
+        raise AssertionError()
+
+
+def combined_component_check(tag_components):
+    """
+    Runs checks on component lists that are meant to include combinations of
+    component and tag. This is a measure to have tidy code.
+    """
+    if "tag1" and "tag2" and "tag3" not in tag_components.keys():
+        raise AssertionError(tag_components.keys())
+    if "component1" and "component2" not in tag_components["tag2"]:
+        raise AssertionError()
+    if not len(tag_components["tag1"]) == 1:
+        raise AssertionError()
+    if not len(tag_components["tag2"]) == 2:
+        raise AssertionError()
+    if not len(tag_components["tag3"]) == 1:
+        raise AssertionError()
+
+
+def test_add_component():
+    """
+    Checks that adding components modifies the tag_component list correctly.
+    """
+    component1 = FakeComponent("component1", ['tag1', 'tag2'])
+    component2 = FakeComponent("component2", ['tag2', 'tag3'])
+    taglist = TagList()
+    taglist.add_component(component1)
+    taglist.add_component(component2)
+    combined_component_check(taglist.tag_components)
+
+
+def test_append_taglist():
+    """
+    Checks that appending taglists works correctly and is commutative.
+    """
+    component1 = FakeComponent("component1", ['tag1', 'tag2'])
+    component2 = FakeComponent("component2", ['tag2', 'tag3'])
+    taglist1 = TagList()
+    taglist1.add_component(component1)
+    taglist2 = TagList()
+    taglist2.add_component(component2)
+    taglist1.append(taglist2)
+    taglist2.append(taglist1)
+    combined_component_check(taglist1.tag_components)
+    combined_component_check(taglist2.tag_components)

--- a/tests/test_taglist.py
+++ b/tests/test_taglist.py
@@ -71,3 +71,33 @@ def test_append_taglist():
     taglist2.append(taglist1)
     combined_component_check(taglist1.tag_components)
     combined_component_check(taglist2.tag_components)
+
+
+def test_get_component_list():
+    """
+    Checks that getting component lists given a set of tags works correctly.
+    """
+    component1 = FakeComponent("component1", ['tag1', 'tag2'])
+    component2 = FakeComponent("component2", ['tag2', 'tag3'])
+    taglist = TagList()
+    taglist.add_component(component1)
+    taglist.add_component(component2)
+    if not len(taglist.get_components_that_match_tags(["tag1"])) == 1:
+        raise AssertionError()
+    if "component1" not in taglist.get_components_that_match_tags(["tag1"]):
+        raise AssertionError()
+    if not len(taglist.get_components_that_match_tags(["tag2"])) == 2:
+        raise AssertionError()
+
+    double_tag_list = taglist.get_components_that_match_tags(["tag2", "tag3"])
+    if not len(double_tag_list) == 1:
+        raise AssertionError()
+    if "component2" not in double_tag_list:
+        raise AssertionError()
+
+    if not len(taglist.get_components_that_match_tags(["tag_umpt"])) == 0:
+        raise AssertionError()
+    if not len(taglist.get_components_that_match_tags(["tag1",
+                                                       "tag2",
+                                                       "tag3"])) == 0:
+        raise AssertionError()

--- a/tests/test_taglist.py
+++ b/tests/test_taglist.py
@@ -10,6 +10,7 @@ class FakeComponent:
         self.tags = tags
 
     def get_full_id(self):
+        """Fake ID function that simply returns this instance's name"""
         return (self.name)
 
 


### PR DESCRIPTION
Adds the 'taglist' concept to an AssetPack, providing an easy way to search for ID's of components in the AssetPack that match an array of tags. A separate component finder class is not necessary.